### PR TITLE
Fixing the path to require.js in the shopping list tutorial

### DIFF
--- a/docs/tutorial/shopping.rst
+++ b/docs/tutorial/shopping.rst
@@ -100,7 +100,7 @@ Seed the :file:`index.html` with the following markup. If you initialized the pr
        <meta charset="utf-8" />
        <title>Cooperative Shopping List Example</title>
        <link rel="stylesheet" href="colist.css" type="text/css" />
-       <script data-main="main" src="../lib/require.js"></script>
+       <script data-main="main" src="./lib/require.js"></script>
      </head>
      <body class="claro">
        <h1>Hello World!</h1>


### PR DESCRIPTION
Hello!

At least when using the Python server (I haven't tested the Java one), the path to requirejs is wrong.

I have been following the example app to the T, using copy paste, and the path is listed as `'../lib/require.js'` in `index.html`, which is equivalent to `"/lib/require.js"` (which is a 404). It should be `'./lib/require.js'` which is equivalent to `'/mycolist/lib/require.js'`.

FYI: I know this is a very small change, but FWIW, I already have a Dojo CLA on file.

Thanks!

Nick
