### PR TITLE
Add dojo.parser.parse() before second checkpoint in tutorial

### DIFF
--- a/docs/tutorial/shopping.rst
+++ b/docs/tutorial/shopping.rst
@@ -238,6 +238,9 @@ Next, replace the :func:`console.log` call in the :func:`dojo.ready` callback wi
 
 .. sourcecode:: javascript
 
+   // parse declarative widgets
+   dojo.parser.parse();
+
    // configure the grid datastore, starting it empty
    var emptyData = {identifier : 'id', label : 'name', items: []};
    var dataStore = new dojo.data.ItemFileWriteStore({data : emptyData});


### PR DESCRIPTION
At the second checkpoint in the tutorial, to do the things it said I needed to, I had to add this dojo.parser.parse() line which I found from the coweb examples repo. Otherwise, the app would not work.
