### PR TITLE
Proposed fix for issue #225: Optional argument for prepare to pass application specific data to moderator callbacks

### DIFF
--- a/servers/java/coweb-javascript/src/main/webapp/coweb/session/BayeuxSession.js
+++ b/servers/java/coweb-javascript/src/main/webapp/coweb/session/BayeuxSession.js
@@ -286,7 +286,7 @@ define([
 
         // only do actual prep if the session has reported it is ready
         // try to prepare conference
-        this._bridge.prepare(params.key, params.collab, this._cacheState, requestUrl, sessionName)
+        this._bridge.prepare(params.key, params.collab, this._cacheState, requestUrl, sessionName,params.userDefined)
             .then('_onPrepared', '_onPrepareError', this);
         // start listening to disconnections
         this._bridge.disconnectPromise.then('_onDisconnected', null, this);

--- a/servers/java/coweb-javascript/src/main/webapp/coweb/session/bayeux/CowebExtension.js
+++ b/servers/java/coweb-javascript/src/main/webapp/coweb/session/bayeux/CowebExtension.js
@@ -19,6 +19,7 @@ define(function() {
         this._cometd = null;
         this._sessionid = args.sessionid;
         this._updaterType = args.updaterType;
+        this._userDefined = args.userDefined || {}
     };
     
     /**
@@ -52,6 +53,7 @@ define(function() {
         var coweb = msg.ext.coweb = msg.ext.coweb || {};
         coweb.sessionid = this._sessionid;
         coweb.updaterType = this._updaterType;
+        msg.ext.userDefined = this._userDefined;
         return msg;
     };
 

--- a/servers/java/coweb-javascript/src/main/webapp/coweb/session/bayeux/SessionBridge.js
+++ b/servers/java/coweb-javascript/src/main/webapp/coweb/session/bayeux/SessionBridge.js
@@ -121,7 +121,7 @@ define([
 	 * @params {String} requestUrl The url of the page making this prep request.
      * @returns {Promise} Resolved on response from server
      */
-    proto.prepare = function(key, collab, cacheState, requestUrl, sessionName) {
+    proto.prepare = function(key, collab, cacheState, requestUrl, sessionName, userDefined) {
         // make sure we're idle
         if(this._state !== this.IDLE) {
             throw new Error(this.id + ': ' +messages.preparenonidlestate);
@@ -150,6 +150,7 @@ define([
         promise.then('_onPrepareResponse', '_onPrepareError', this);
         // change state to avoid duplicate prepares
         this._state = this.PREPARING;
+        this._userDefined = userDefined || {};
         return this._prepPromise;
     };
 
@@ -198,7 +199,8 @@ define([
         this._joinPromise = new Promise();
         // register extension to include session id in ext        
         cometd.unregisterExtension('coweb');
-        var args = {sessionid : this.prepResponse.sessionid, updaterType: updaterType};
+        var args = {sessionid : this.prepResponse.sessionid, updaterType: updaterType, userDefined: this._userDefined};
+
         cometd.registerExtension('coweb', new CowebExtension(args));
 
         cometd.configure({


### PR DESCRIPTION
This adds the optional argument 'userDefined' to prepare to pass user-defined data to server implementation:
    session.prepare({key: 'someKey', userDefined: {token: 'someToken', otherData: 'other'}})

This userDefined can be used in the server-side moderator implementation, for example to identify the user in canClientJoinSession: 

```
@Override
public synchronized boolean canClientJoinSession(ServerSession client, Message message) {
    String token = (String) ((Map<String, Object>) message.getExt().get(
            "userDefined")).get("token");
    return customTokenVerifcation(token);
}
```

This might be a somewhat hacky solution but for me, it works. 
