### PR TITLE
Fix for python bytes-to-utf-8  encoded string in the usernames

### DIFF
--- a/servers/python/coweb/session/session.py
+++ b/servers/python/coweb/session/session.py
@@ -231,7 +231,7 @@ class SessionConnection(bayeux.BayeuxConnection):
     '''Connection for uncollaborative sessions.'''
     def on_auth_ext(self, cl, auth):
         '''Overrides to use cookie + db for Bayeux authentication.'''
-        username = self._handler.current_user
+        username = self._handler.current_user.decode('utf-8')
         if username is None: return False
         # check credentials in the db
         return self._manager.authorize_user(username)
@@ -239,7 +239,7 @@ class SessionConnection(bayeux.BayeuxConnection):
     def on_handshake(self, cl, req, res):
         '''Overrides to attach authed username to client.'''
         if res['successful']:
-            cl.username = self._handler.current_user
+            cl.username = self._handler.current_user.decode('utf-8')
 
     def on_unknown_client(self, res):
         '''Overrides to prevent reconnects from dead clients.'''


### PR DESCRIPTION
This fixes the  session join problem  opencoweb/coweb#236   that the >1 client has  with opencoweb+tornado>=3.x, this is only minimally tested with tornado 2.x and tornado 3.1.1 on python 3.3.2  and   OCW 5822afaa46e3369eb6970d44563172bf7f7bf92d  
