### PR TITLE
Fix python server if httpStaticPath is None

### DIFF
--- a/servers/python/coweb/container.py
+++ b/servers/python/coweb/container.py
@@ -64,7 +64,8 @@ class AppContainer(object):
         self.on_configure()
 
         # adjust all paths to make them absolute relative to container loc now
-        self.httpStaticPath = self.get_absolute_path(self.httpStaticPath)
+        if self.httpStaticPath is not None:
+            self.httpStaticPath = self.get_absolute_path(self.httpStaticPath)
         for i, path in enumerate(self.cowebBotLocalPaths):
             self.cowebBotLocalPaths[i] = self.get_absolute_path(path)
 


### PR DESCRIPTION
The documentation says, you could set httpStaticPath to None in the configuration, but this does not work.
